### PR TITLE
update shiny template link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ It is vital that users are part of the development, or re-development, of a stat
 - *Coming soon*: Usability testing guidance paper
 
 ### Transforming output
-- Use this [**blank RShiny template**](https://github.com/Health-SocialCare-Scotland/r-project-structure) when starting to build a new app or dashboard to ensure you have a sensible workflow and structure.
+- Use this [**blank RShiny template**](https://github.com/Health-SocialCare-Scotland/rshiny-project-structure) when starting to build a new app or dashboard to ensure you have a sensible workflow and structure.
 - Follow these examples of our existing RShiny dashboards for good practice in terms of both coding and design: [**Psychiatric Inpatient Activity Data Explorer code**](https://github.com/Health-SocialCare-Scotland/Psychiatric-Inpatient-Activity) and [**Acute Activity Data Explorer code**](https://github.com/Health-SocialCare-Scotland/Hospital-Acute-Activity).
 - *Coming soon*: Chart and dashboard guidance paper


### PR DESCRIPTION
The link to the shiny template repo was pointing to the project template repo, just updating it.